### PR TITLE
issue #17 x11 not working on ubuntu 18.04

### DIFF
--- a/docker-wine
+++ b/docker-wine
@@ -36,7 +36,7 @@ fi
 docker run -it \
     --rm \
     --env="DISPLAY" \
-    --volume="$HOME/.Xauthority:/root/.Xauthority:ro" \
+    --volume="${XAUTHORITY}:/root/.Xauthority:ro" \
     --volume="winehome${branch}:/home/wine" \
     --net="host" \
     --name="wine${branch}" \


### PR DESCRIPTION
BREAKING CHANGE: using  env variable to fix X11 forwarding on Ubuntu 18.04 bionic

Fixes issue #17 