### PR TITLE
Fix wrong path for /tmp/.X11-unix

### DIFF
--- a/docker-wine
+++ b/docker-wine
@@ -6,7 +6,7 @@ docker_run () {
     --rm \
     --env="DISPLAY" \
     --volume="${XAUTHORITY}:/root/.Xauthority:ro" \
-    --volume="/tmp/.X11-unix:/tmp/X11-unix:ro" \
+    --volume="/tmp/.X11-unix:/tmp/.X11-unix:ro" \
     --volume="/etc/localtime:/etc/localtime:ro" \
     --volume="winehome:/home/wineuser" \
     --hostname="winecellar" \
@@ -21,7 +21,7 @@ docker_run_with_audio () {
     --rm \
     --env="DISPLAY" \
     --volume="${XAUTHORITY}:/root/.Xauthority:ro" \
-    --volume="/tmp/.X11-unix:/tmp/X11-unix:ro" \
+    --volume="/tmp/.X11-unix:/tmp/.X11-unix:ro" \
     --volume="/tmp/pulse-socket:/tmp/pulse-socket" \
     --volume="/etc/localtime:/etc/localtime:ro" \
     --volume="winehome:/home/wineuser" \


### PR DESCRIPTION
The volume /tmp/.X11-unix was mapped as /tmp/X11-unix, using the correct path /tmp/.X11-unix