### PR TITLE
Bump up winehq version; support buildah as alternative to docker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,20 @@ fi
 BUILD_TARGET="$1"
 VERSION=$(cat ./VERSION)
 
+BUILDER="docker build"
+if ! ${BUILDER%% *} -v >/dev/null 2>&1; then
+    BUILDER="buildah bud"
+    if ! ${BUILDER%% *} -v >/dev/null 2>&1; then
+        echo "Didn't find docker or buildah."
+        exit 1
+    else
+        echo "Didn't find docker, did find buildah, using buildah."
+    fi
+fi
+
 source ./build_args/${BUILD_TARGET}
 
-docker build \
+$BUILDER \
     --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
     --build-arg GECKO_VER=$GECKO_VER \
     --build-arg GIT_REV=$(git rev-parse HEAD) \

--- a/build_args/ubuntu-stable
+++ b/build_args/ubuntu-stable
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 export WINEBRANCH="stable"
-export WINE_VER="4.0.1~bionic"
+export WINE_VER="4.0.2~bionic"
 export MONO_VER="4.7.5"
 export GECKO_VER="2.47"


### PR DESCRIPTION
Here are two commit.  The first bumps up the stable `winehq` version from 4.0.1 (which isn't available) to 4.0.2.  The second automatically switches from using `docker build` to using `buildah bud`  iff `docker` isn't available but `buildah` is.  This allows for running `make` on systems which are using `podman` instead of `docker` (likely with current RHEL/CentOS systems.)