### PR TITLE
refactor: git pre-commit cleanups

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,14 +41,14 @@ if echo "${RDP_SERVER}" | grep -q -i -E "^(no|off|false|0)$"; then
 
     # Run xvfb
     if echo "${XVFB}" | grep -q -i -E "^(yes|on|true|1)$"; then
-        nohup /usr/bin/Xvfb ${XVFB_SERVER} -screen ${XVFB_SCREEN} ${XVFB_RESOLUTION} >/dev/null 2>&1 &
+        nohup /usr/bin/Xvfb "${XVFB_SERVER}" -screen "${XVFB_SCREEN}" "${XVFB_RESOLUTION}" >/dev/null 2>&1 &
     fi
 
     # Run in X11 redirection mode as $USER_NAME (default)
     if echo "${RUN_AS_ROOT}" | grep -q -i -E "^(no|off|false|0)$"; then
 
         # Copy and take ownership of .Xauthority for X11 redirection
-        if [ -f /root/.Xauthority -a "${XVFB}" == "no" ]; then
+        if [ -f /root/.Xauthority ] && [ "${XVFB}" == "no" ]; then
             cp /root/.Xauthority "${USER_HOME}"
             chown "${USER_UID}":"${USER_GID}" "${USER_HOME}/.Xauthority"
         fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,19 +1,38 @@
 #!/usr/bin/env bash
 
-# This file should be copied to <repo root>/.git/hooks/pre-commit to enable pre-commit checks
+# Enable this hook by editing the project specific "hooksPath" config variable:
+# git config core.hooksPath "${REPO_ROOT}/hooks/"
+
+set -eu
 
 # Redirect output to stderr
 exec 1>&2
 
-# Check shellcheck available
-if ! command -v shellcheck >/dev/null 2>&1; then
-    echo "ERROR: shellcheck does not appear to be installed"
-    exit 1
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=$(git hash-object -t tree /dev/null)
 fi
 
 # Run shellcheck on all shell files
-for FILE in $(git diff --cached --name-only); do
-    if head -1 "${FILE}" | grep -q -E "^#!.*sh$"; then
-        shellcheck "${FILE}" || exit 1
+SHELL_SCRIPTS=()
+for FILE in $(git diff-index --cached --diff-filter=d --name-only "$against"); do
+    if head -n 1 "${FILE}" | grep -q -e '^#![[:print:]]*[^c]sh$'; then
+        SHELL_SCRIPTS+=("$FILE")
     fi
 done
+
+if [ -n "${SHELL_SCRIPTS[0]}" ]; then
+    if ! shellcheck "${SHELL_SCRIPTS[@]}"; then
+        echo "Shellcheck errors, or not installed, commit rejected"
+        exit 1
+    fi
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+if ! git diff-index --check --cached "$against" --; then
+    echo "Whitespace errors, commit rejected"
+    exit 1
+fi


### PR DESCRIPTION
* Recommend using git config "hooksPath" over `cp` to pick up changes in
  hooks folder.
* Use strict shell programming with -e (Abort script at first error) and
  -u (Treat unset variables and parameters as an error at expansion).
* Only check for Shellcheck if changes to shell scripts are to be
  committed.
* Use git diff-index as the example git pre-commit examples do.
* Aggregate all changed shell scripts into one call to Shellcheck for a
  minor speed improvement (0.5 sec improvement for 100 shell scripts)
* Use POSIX compliant call to head with -n option
* Improve grep call
  * Do not rely on extended patterns
  * POSIX recommends -e with single quotes
  * Shellcheck does not check [t]csh scripts
* Add check with Git's default whitespace checker
* Apply Shellcheck to all files in repo.