### PR TITLE
fix: Fix faulty empty array check in pre-commit

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Enable this hook by editing the project specific "hooksPath" config variable:
-# git config core.hooksPath "${REPO_ROOT}/hooks/"
+# git config core.hooksPath "${REPO_ROOT}/hooks"
 
 set -eu
 
@@ -24,7 +24,7 @@ for FILE in $(git diff-index --cached --diff-filter=d --name-only "$against"); d
     fi
 done
 
-if [ -n "${SHELL_SCRIPTS[0]}" ]; then
+if (( ${#SHELL_SCRIPTS[@]} )); then
     if ! shellcheck "${SHELL_SCRIPTS[@]}"; then
         echo "Shellcheck errors, or not installed, commit rejected"
         exit 1


### PR DESCRIPTION
Whoops, forgot to test if no changed shelll scripts in stage

* When no shell scripts were changed the empty array was checked using a
  defrefrence of an unset variable, causing an error. Use arithmetic an
  expression to test the count in the array.
* Remove trailing slash on `hooksPath` to prevent double slash in
  printing errors and keeping with git conventions:
  https://git-scm.com/docs/git-config#Documentation/git-config.txt-corehooksPath