### PR TITLE
remove the sesman pidfile if it exists at startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,6 +83,12 @@ elif is_enabled "${RDP_SERVER}"; then
         exit 1
     fi
 
+    # If the pid for sesman is there we need to remove it
+    # or sesman won't start and connections will fail
+    if [ -f /var/run/xrdp/xrdp-sesman.pid ]; then
+	rm /var/run/xrdp/xrdp-sesman.pid
+    fi
+
     # Start xrdp sesman service
     /usr/sbin/xrdp-sesman
 


### PR DESCRIPTION
When using `docker-compose up` an anonymous volume is created.  If a session is open and the container is terminated, the pidfile for `xrdp-sesman` is not removed.  When the container is restarted, and the same volume is used, `xrdp-sesman` will fail to start because of the pidfile.  This prevents connections to the xrdp server.

This patch will simply remove the pidfile if it exists prior to launching the xrdp-sesman