### PR TITLE
Feature/xauth

### DIFF
--- a/docker-wine
+++ b/docker-wine
@@ -205,6 +205,22 @@ install_xquartz() {
     return $installed
 }
 
+add_x11_key () {
+    local display="$1"
+
+    # Check for .Xauthority which is required for authenticating as the current user on the host's X11 server
+    if [ -z "${XAUTHORITY:-${HOME}/.Xauthority}" ]; then
+        echo "ERROR: No valid .Xauthority file found for X11"
+        exit 1
+    fi
+
+    # Get the hex key for the display from host user's .Xauthority file and store in ~/.docker-wine.Xkey
+    xauth list "${display}" | head -n1 | awk '{print $3}' > ~/.docker-wine.Xkey
+
+    # Add .Xkey to the run args
+    add_run_arg --volume="${HOME}/.docker-wine.Xkey:/root/.Xkey:ro"
+}
+
 run_container () {
     local mode
 
@@ -457,29 +473,24 @@ else
             exit 0
         fi
 
-        # Ensure XQuartz is running
+        # Ensure XQuartz is running so ~/.Xauthority file is updated with new X11 key
         if ! ps -e | awk '{print $4}' | grep -q "/opt/X11/bin/Xquartz"; then
             open -a xquartz
         fi
 
-        # Get the hex key for the display from our .Xauthority file and store in ~/.docker-wine/.Xkey
-        [ ! -d ~/.docker-wine ] && mkdir ~/.docker-wine
-        xauth list "$(ipconfig getifaddr en0):0" | awk '{print $3}' > ~/.docker-wine/.Xkey
+        # Store the X11 key for the display in ~/.docker-wine.Xkey and add to run args
+        add_x11_key ":0"
 
         # Add macOS run args
         add_run_arg --env="DISPLAY=host.docker.internal:0"
-        add_run_arg --volume="${HOME}/.docker-wine/.Xkey:/root/.Xkey:ro"
 
         run_container "interactive"
 
     # Run in X11 forwarding mode on Linux
     elif [ "$(uname)" == "Linux" ]; then
 
-        # Check for .Xauthority which is required for authenticating as the current user on the host's X11 server
-        if [ -z "${XAUTHORITY:-${HOME}/.Xauthority}" ] && [ "${USE_XVFB}" == "no" ]; then
-            echo "ERROR: No valid .Xauthority file found for X11"
-            exit 1
-        fi
+        # Store the X11 key for the display in ~/.docker-wine.Xkey and add to run args
+        add_x11_key "$DISPLAY"
 
         # Use audio if pulseaudio is installed
         if command -v pulseaudio >/dev/null 2>&1; then
@@ -511,7 +522,6 @@ else
 
         # Add Linux run args
         add_run_arg --env="DISPLAY"
-        add_run_arg --volume="${XAUTHORITY:-${HOME}/.Xauthority}:/root/.Xauthority:ro"
         add_run_arg --volume="/tmp/.X11-unix:/tmp/.X11-unix:ro"
 
         run_container "interactive"

--- a/docker-wine
+++ b/docker-wine
@@ -457,14 +457,18 @@ else
             exit 0
         fi
 
-        # Allow localhost to access XQuartz
-        if ! xhost | grep -q "^INET:localhost$"; then
-            echo "WARNING: Adding localhost to authorized xhost clients"
-            xhost + 127.0.0.1
+        # Ensure XQuartz is running
+        if ! ps -e | awk '{print $4}' | grep -q "/opt/X11/bin/Xquartz"; then
+            open -a xquartz
         fi
+
+        # Get the hex key for the display from our .Xauthority file and store in ~/.docker-wine/.Xkey
+        [ ! -d ~/.docker-wine ] && mkdir ~/.docker-wine
+        xauth list "$(ipconfig getifaddr en0):0" | awk '{print $3}' > ~/.docker-wine/.Xkey
 
         # Add macOS run args
         add_run_arg --env="DISPLAY=host.docker.internal:0"
+        add_run_arg --volume="${HOME}/.docker-wine/.Xkey:/root/.Xkey:ro"
 
         run_container "interactive"
 

--- a/docker-wine
+++ b/docker-wine
@@ -217,6 +217,9 @@ add_x11_key () {
     # Get the hex key for the display from host user's .Xauthority file and store in ~/.docker-wine.Xkey
     xauth list "${display}" | head -n1 | awk '{print $3}' > ~/.docker-wine.Xkey
 
+    # Lock down permissions
+    chmod 600 ~/.docker-wine.Xkey
+
     # Add .Xkey to the run args
     add_run_arg --volume="${HOME}/.docker-wine.Xkey:/root/.Xkey:ro"
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,12 @@ if is_disabled "${RDP_SERVER}"; then
         nohup /usr/bin/Xvfb "${XVFB_SERVER}" -screen "${XVFB_SCREEN}" "${XVFB_RESOLUTION}" >/dev/null 2>&1 &
     fi
 
+    # Generate .Xauthority using xauth with .Xkey sourced from host
+    if [ -f /root/.Xkey ]; then
+        [ ! -f /root/.Xauthority ] && touch /root/.Xauthority
+        xauth add "$DISPLAY" . "$(cat /root/.Xkey)"
+    fi
+
     # Run in X11 redirection mode as $USER_NAME (default)
     if is_disabled "${RUN_AS_ROOT}"; then
 


### PR DESCRIPTION
This feature improves security on macOS by using `xauth`  instead of `xhost` to enable access to the X server.

This change has also been applied to using X11 on Linux so that you no longer need to share the user's Xauthority file with the container (so in theory could allow the container hostname to be changed), but will still work if a user chooses to do so.

This new method works by extracting the X11 key from the user's Xauthority file with `xauth` and storing it in `~/.docker-wine.Xkey`.  This file is then mounted onto the container as `/root/.Xkey` and combined with `xauth` in the `/usr/bin/entrypoint` script to generate an MIT magic cookie for the X11 display in the container's `~/.Xauthority` file.

