### PR TITLE
Feature/no sound

### DIFF
--- a/docker-wine
+++ b/docker-wine
@@ -52,7 +52,8 @@ print_help () {
     echo "                                           connect to the host machine's"
     echo "                                           pulseaudio server (Linux only)"
     echo "                          dummy          Run pulseaudio server in container with"
-    echo "                                           dummy output"
+    echo "                                           dummy (null) output"
+    echo "                          none           Alias for dummy"
     echo "  --home-volume=VALUE   Use an alternate volume to winehome for storing"
     echo "                          persistent user data. Valid values can specify either"
     echo "                          a docker volume or local path"
@@ -259,7 +260,7 @@ configure_sound () {
         unix)
             configure_pulseaudio_unix_socket
             ;;
-        dummy)
+        dummy|none)
             add_run_arg --env="DUMMY_PULSEAUDIO=yes"
             ;;
         *)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ ln -snf "/usr/share/zoneinfo/${TZ}" /etc/localtime && echo "${TZ}" > /etc/timezo
 if is_disabled "${RDP_SERVER}"; then
 
     # Set up pulseaudio for redirection to UNIX socket
-    if is_disabled "${DUMMY_PULSEAUDIO}"; then
+    if is_disabled "${DUMMY_PULSEAUDIO}" && [ -e /tmp/pulse-socket ]; then
         [ -f /root/pulse/client.conf ] && cp /root/pulse/client.conf /etc/pulse/client.conf
     fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,6 +92,11 @@ elif is_enabled "${RDP_SERVER}"; then
         exit 1
     fi
 
+    # Remove xrdp pulseaudio source and sink modules if using dummy sound option
+    if is_enabled "${DUMMY_PULSEAUDIO}"; then
+        rm -f /var/lib/xrdp-pulseaudio-installer/module-xrdp-{sink,source}.so
+    fi
+
     # If the pid for sesman is there we need to remove it
     # or sesman won't start and connections will fail
     if [ -f /var/run/xrdp/xrdp-sesman.pid ]; then
@@ -103,7 +108,7 @@ elif is_enabled "${RDP_SERVER}"; then
 
     # Run xrdp in foreground if no commands specified
     if [ -z "$1" ]; then
-        /usr/sbin/xrdp --nodaemon
+        exec /usr/sbin/xrdp --nodaemon
     else
         /usr/sbin/xrdp
 


### PR DESCRIPTION
* add `--sound=none` option to docker-wine script, which is just an alias for dummy mode
* when running in X11 mode, only copy the pulseaudio config file for redirection if the unix socket exists
* add dummy sound option to RDP

Relates to issue #83