### PR TITLE
brew cask install has been deprecated

### DIFF
--- a/docker-wine
+++ b/docker-wine
@@ -218,7 +218,7 @@ install_xquartz() {
 
     # Install XQuartz
     if ! [ -f /opt/X11/bin/xquartz ]; then
-        brew cask install xquartz
+        brew install --cask xquartz
 
         # Confirm installed
         [ -f /opt/X11/bin/xquartz ] && installed=0


### PR DESCRIPTION
brew cask install has been deprecated in favour of brew install --cask

more information: https://brew.sh/2020/12/01/homebrew-2.6.0/
"All brew cask commands have been deprecated in favour of brew commands (with --cask) when necessary"