### PR TITLE
feat: add arm64 platform to builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,9 @@ jobs:
             WINE_BRANCH=${{ matrix.wine_branch }}
           push: true
           tags: ${{ steps.tags.outputs.value }}
+          platforms:
+            linux/amd64,
+            linux/arm64
       -
         name: Update repo description
         uses: peter-evans/dockerhub-description@v2


### PR DESCRIPTION
Adding ARM64 platform to builds to resolve issue for Mac M1 CPUs as reported in #109